### PR TITLE
Use @metrics/metric

### DIFF
--- a/lib/collector-active-handles-total.js
+++ b/lib/collector-active-handles-total.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 
 const CollectorActiveHandlesTotal = class CollectorActiveHandlesTotal {
     constructor(prefix = '') {

--- a/lib/collector-active-requests-total.js
+++ b/lib/collector-active-requests-total.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 
 const CollectorActiveRequestsTotal = class CollectorActiveRequestsTotal {
     constructor(prefix = '') {

--- a/lib/collector-cpu-total.js
+++ b/lib/collector-cpu-total.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 
 const CollectorCpuTotal = class CollectorCpuTotal {
     constructor(prefix = '') {

--- a/lib/collector-eventloop-lag.js
+++ b/lib/collector-eventloop-lag.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 
 const CollectorEventloopLag = class CollectorEventloopLag {
     constructor(prefix = '') {

--- a/lib/collector-heap-used-and-size.js
+++ b/lib/collector-heap-used-and-size.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 
 const CollectorHeadUsedAndSize = class CollectorHeadUsedAndSize {
     constructor(prefix = '') {

--- a/lib/collector-max-file-descriptors.js
+++ b/lib/collector-max-file-descriptors.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 const fs = require('fs');
 
 const CollectorMaxFileDescriptors = class CollectorMaxFileDescriptors {

--- a/lib/collector-open-file-descriptors.js
+++ b/lib/collector-open-file-descriptors.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 const fs = require('fs');
 
 const CollectorOpenFileDescriptors = class CollectorOpenFileDescriptors {

--- a/lib/collector-process-resident-memory.js
+++ b/lib/collector-process-resident-memory.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 const fs = require('fs');
 
 const generic = Symbol('generic');

--- a/lib/collector-process-start-time.js
+++ b/lib/collector-process-start-time.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 
 const START_TIME = Math.round(Date.now() / 1000 - process.uptime());
 

--- a/lib/collector-v8-heap.js
+++ b/lib/collector-v8-heap.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 const v8 = require('v8');
 
 const CollectorV8Heap = class CollectorV8Heap {

--- a/lib/collector-version.js
+++ b/lib/collector-version.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 
 const CollectorVersion = class CollectorVersion {
     constructor(prefix = '') {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,16 @@
     "url": "https://github.com/metrics-js/process/issues"
   },
   "homepage": "https://github.com/metrics-js/process#readme",
+  "keywords": [
+    "server-statistics",
+    "server-stats",
+    "statistics",
+    "metrics",
+    "monitoring",
+    "process"
+  ],
   "dependencies": {
-    "@metrics/client": "^2.2.0",
+    "@metrics/metric": "^1.0.0",
     "deferred-interval": "^2.0.0",
     "readable-stream": "^3.1.0"
   },


### PR DESCRIPTION
This uses the `@metrics/metric` module instead of deep diving into the file structure of `@metrics/client`.