### PR TITLE
Limit published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.1.0",
   "description": "Module for collecting different process and system metrics and providing them as a metric stream",
   "main": "lib/process.js",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "test": "tap test/*.js",
     "test:coverage": "tap test/*.js --cov",


### PR DESCRIPTION
Currently a lot of non vital files such as test files etc goes into package. Reduce the amount of files published to only be lib files.