### PR TITLE
Make max fds to report process limit instead of OS limit

### DIFF
--- a/lib/collector-max-file-descriptors.js
+++ b/lib/collector-max-file-descriptors.js
@@ -29,11 +29,28 @@ const CollectorMaxFileDescriptors = class CollectorMaxFileDescriptors {
         }
 
         return new Promise((resolve) => {
-            fs.readFile('/proc/sys/fs/file-max', 'utf8', (error, result) => {
+            fs.readFile('/proc/self/limits', 'utf8', (error, limits) => {
+
                 if (error) {
                     resolve(null);
                     return;
                 }
+
+                const lines = limits.split('\n');
+
+                let result = '';
+                lines.find((line) => {
+                    if (line.startsWith('Max open files')) {
+                        const parts = line.split(/  +/);
+                        result = parts[1];
+                        return true;
+                    }
+                });
+
+                if (result === '') {
+                    resolve(null);
+                    return;
+                };
 
                 resolve([new Metric({
                     name: `${this.prefix}process_max_fds`,

--- a/lib/collector-max-file-descriptors.js
+++ b/lib/collector-max-file-descriptors.js
@@ -30,7 +30,6 @@ const CollectorMaxFileDescriptors = class CollectorMaxFileDescriptors {
 
         return new Promise((resolve) => {
             fs.readFile('/proc/self/limits', 'utf8', (error, limits) => {
-
                 if (error) {
                     resolve(null);
                     return;
@@ -41,16 +40,16 @@ const CollectorMaxFileDescriptors = class CollectorMaxFileDescriptors {
                 let result = '';
                 lines.find((line) => {
                     if (line.startsWith('Max open files')) {
-                        const parts = line.split(/  +/);
-                        result = parts[1];
+                        [, result] = line.split(/  +/);
                         return true;
                     }
+                    return false;
                 });
 
                 if (result === '') {
                     resolve(null);
                     return;
-                };
+                }
 
                 resolve([new Metric({
                     name: `${this.prefix}process_max_fds`,


### PR DESCRIPTION
This makes max fds to report the max limit from the process instead of the max limit of the OS. This change mimics changes made to the original prom-client.