### PR TITLE
Add GC collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 Module for collecting different process and system metrics providing them as a metric stream.
 
-[![Dependencies](https://img.shields.io/david/metrics-js/process.svg?style=flat-square)](https://david-dm.org/metrics-js/process)
-[![Build Status](http://img.shields.io/travis/metrics-js/process/master.svg?style=flat-square)](https://travis-ci.org/metrics-js/process)
-[![Greenkeeper badge](https://badges.greenkeeper.io/metrics-js/process.svg?style=flat-square)](https://greenkeeper.io/)
-[![Known Vulnerabilities](https://snyk.io/test/github/metrics-js/process/badge.svg?targetFile=package.json&style=flat-square)](https://snyk.io/test/github/metrics-js/process?targetFile=package.json)
+[![Dependencies](https://img.shields.io/david/metrics-js/process.svg)](https://david-dm.org/metrics-js/process)
+[![GitHub Actions status](https://github.com/metrics-js/process/workflows/Run%20Lint%20and%20Tests/badge.svg)](https://github.com/metrics-js/process/actions?query=workflow%3A%22Run+Lint+and+Tests%22)
+[![Known Vulnerabilities](https://snyk.io/test/github/metrics-js/process/badge.svg?targetFile=package.json)](https://snyk.io/test/github/metrics-js/process?targetFile=package.json)
 
 ## Installation
 
@@ -57,7 +56,8 @@ proc.start();
 ```
 
 Each metric is collected by a collector. Most collectors will provide metrics on each scheduled
-run but some metrics will only run once due to its nature. Some metrics will not be collected on
+run or when the underlaying feature for generating the metric emits to build the metric out of,
+but some metrics will only run once due to its nature. Some metrics will not be collected on
 some operating systems. Please see [collectors](#collectors) for further detail.
 
 ### On not staying alive
@@ -94,10 +94,16 @@ Returns a Readable stream in object mode.
 
 The Process instance has the following API:
 
-### .start()
+### .start(options)
 
 Starts the scheduling of metric collection. The first run of metric collection will run immediately
 upon calling this method.
+
+### options (optional)
+
+An Object containing misc configuration. The following values can be provided:
+
+ * **gc** - `Boolean` - Turns collection of gc metrics on or off. Default: false.
 
 ### .stop()
 
@@ -302,6 +308,23 @@ The Active handles collector emits a metric with the number of open handles (suc
  * **metric name:** nodejs_active_handles_total
  * **collected when:** On every collect
  * **collected on:** All operating systems if `process._getActiveRequests()` is available
+
+### Garbage collection
+
+The garbage collection (GC) collector emits a metric timing the length of the GC everytime
+a GC has run.
+
+Do note that collecting metrics on GC has a performance impact on the system in it self.
+Its adviced that collecting GC metrics should be done in moderation and for small periods
+of time.
+
+Collecting GC metrics is by default turned off. It can be enabled by the `gc` argument on
+the `.start()` method.
+
+ * **metric name:** nodejs_gc_duration_seconds
+ * **collected when:** When enabled, every time a GC is done
+ * **collected on:** All operating systems
+
 
 ## Attribution
 

--- a/lib/collector-gc.js
+++ b/lib/collector-gc.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const EventEmitter = require('events');
+const perfHooks = require('perf_hooks');
+const Metric = require('@metrics/metric');
+
+const CollectorGC = class CollectorGC extends EventEmitter {
+    constructor(prefix = '') {
+        super();
+
+        const dictionary = new Map([
+            [perfHooks.constants.NODE_PERFORMANCE_GC_MAJOR, 'major'],
+            [perfHooks.constants.NODE_PERFORMANCE_GC_MINOR, 'minor'],
+            [perfHooks.constants.NODE_PERFORMANCE_GC_INCREMENTAL, 'incremental'],
+            [perfHooks.constants.NODE_PERFORMANCE_GC_WEAKCB, 'weakcb'],
+        ]);
+
+        const buckets = [
+            0.001,
+            0.01,
+            0.1,
+            1,
+            2,
+            5
+        ];
+
+        Object.defineProperty(this, 'observer', {
+            value: new perfHooks.PerformanceObserver((list) => {
+                const entry = list.getEntries()[0];
+                const metric = new Metric({
+                    name: `${prefix}nodejs_gc_duration_seconds`,
+                    description: 'Garbage collection duration by kind, one of "major", "minor", "incremental" or "weakcb"',
+                    type: 5,
+                    labels: [
+                        { name: 'kind', value: dictionary.get(entry.kind) },
+                    ],
+                    timestamp: Date.now() / 1000,
+                    value: entry.duration / 1000,
+                    meta: {
+                        buckets,
+                    },
+                });
+                this.emit('metric', metric);
+            }),
+        });
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'CollectorGC';
+    }
+
+    start() {
+        this.observer.observe({ entryTypes: ['gc'], buffered: false });
+    }
+
+    stop() {
+        this.observer.disconnect();
+    }
+};
+
+module.exports = CollectorGC;

--- a/lib/process.js
+++ b/lib/process.js
@@ -80,6 +80,14 @@ const MetricsProcess = class MetricsProcess extends stream.Readable {
         Object.defineProperty(this, 'collectorGC', {
             value: new CollectorGC(prefix),
         });
+
+        this.collectorGC.on('metric', (metric) => {
+            if (this._readableState.flowing) {
+                this.push(metric);
+                return;
+            }
+            this.emit('drop', metric);
+        });
     }
 
     get [Symbol.toStringTag]() {
@@ -103,11 +111,26 @@ const MetricsProcess = class MetricsProcess extends stream.Readable {
         ]);
     }
 
-    start() {
+    start(options = {}) {
+        const o = Object.assign({
+            ver : true,
+            mfd : true,
+            ofd : true,
+            ell : true,
+            pst : true,
+            art : true,
+            aht : true,
+            cpu : true,
+            hus : true,
+            prm : true,
+            v8h : true,
+            gc : false,
+        }, options);
+
         this.scheduler.start(async (done) => {
             this.emit('collect:start');
 
-            const results = await this[collect]();
+            const results = await this[collect](o);
             results.filter((result) => {
                 return Array.isArray(result);
             }).forEach((result) => {
@@ -123,10 +146,15 @@ const MetricsProcess = class MetricsProcess extends stream.Readable {
             this.emit('collect:end');
             done();
         }, this.interval, true);
+
+        if (o.gc) {
+            this.collectorGC.start();
+        }
     }
 
     stop() {
         this.scheduler.stop();
+        this.collectorGC.stop();
     }
 
     _read() {

--- a/lib/process.js
+++ b/lib/process.js
@@ -112,20 +112,21 @@ const MetricsProcess = class MetricsProcess extends stream.Readable {
     }
 
     start(options = {}) {
-        const o = Object.assign({
-            ver : true,
-            mfd : true,
-            ofd : true,
-            ell : true,
-            pst : true,
-            art : true,
-            aht : true,
-            cpu : true,
-            hus : true,
-            prm : true,
-            v8h : true,
-            gc : false,
-        }, options);
+        const o = {
+            ver: true,
+            mfd: true,
+            ofd: true,
+            ell: true,
+            pst: true,
+            art: true,
+            aht: true,
+            cpu: true,
+            hus: true,
+            prm: true,
+            v8h: true,
+            gc: false,
+            ...options
+        };
 
         this.scheduler.start(async (done) => {
             this.emit('collect:start');

--- a/lib/process.js
+++ b/lib/process.js
@@ -14,6 +14,7 @@ const CollectorCPU = require('./collector-cpu-total');
 const CollectorHUS = require('./collector-heap-used-and-size');
 const CollectorPRM = require('./collector-process-resident-memory');
 const CollectorV8H = require('./collector-v8-heap');
+const CollectorGC = require('./collector-gc');
 
 const collect = Symbol('collect');
 
@@ -74,6 +75,10 @@ const MetricsProcess = class MetricsProcess extends stream.Readable {
 
         Object.defineProperty(this, 'collectorV8H', {
             value: new CollectorV8H(prefix),
+        });
+
+        Object.defineProperty(this, 'collectorGC', {
+            value: new CollectorGC(prefix),
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "tap test/*.js",
-    "test:coverage": "tap test/*.js --cov",
+    "test": "tap test/*.js --expose-gc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },

--- a/test/collector-gc.js
+++ b/test/collector-gc.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const tap = require('tap');
+
+const Collector = require('../lib/collector-gc');
+
+// NOTE: This test must be run with the "--expose-gc" argument
+// node --expose-gc collector-gc.js
+
+// Helper to trigger GC
+const gc = () => {
+    return new Promise((resolve, reject) => {
+        try {
+            if (global.gc) {
+                global.gc();
+            } else {
+                reject(new Error('Not able to trigger a GC. Please run the test with the "--expose-gc" argument'));
+            }
+        } catch (error) {
+            reject(error);
+        }
+
+        setTimeout(() => {
+            resolve();
+        }, 40);
+    });
+};
+
+const BUCKETS = [
+    0.001,
+    0.01,
+    0.1,
+    1,
+    2,
+    5
+];
+const KINDS = new Set(['major', 'minor', 'incremental', 'weakcb']);
+
+tap.test('Constructor()', (t) => {
+    const collector = new Collector();
+    t.equal(Object.prototype.toString.call(collector), '[object CollectorGC]', 'Should be of object type [object CollectorGC]');
+    t.type(collector.start, 'function', 'Should have a .start() function');
+    t.type(collector.stop, 'function', 'Should have a .stop() function');
+    t.end();
+});
+
+tap.test('Emitted metric object by GC', async (t) => {
+    const collector = new Collector();
+    collector.on('metric', (metric) => {
+        t.equal(Object.prototype.toString.call(metric), '[object Metric]', 'Metric should be of type [object Metric]');
+        t.equal(metric.name, 'nodejs_gc_duration_seconds', 'Metric should have ".name" property set to "nodejs_gc_duration_seconds"');
+        t.equal(metric.type, 5, 'Metric should have ".type" property set to "5"');
+        t.type(metric.value, 'number', 'Metric should have ".value" with a numeric value');
+        t.equal(metric.labels[0].name, 'kind', 'Metric should have one label with ".name" set to "kind"');
+        t.true(KINDS.has(metric.labels[0].value), 'Metric should have one label with ".value" set to "major", "minor", "incremental" or "weakcb"');
+        t.same(metric.meta.buckets, BUCKETS, 'Metric should have a ".meta.buckets" property set with defined buckets');
+    });
+    collector.start();
+
+    await gc();
+
+    collector.stop();
+});
+
+
+tap.test('"prefix" on constructor is set', async (t) => {
+    const collector = new Collector('foo_');
+    collector.on('metric', (metric) => {
+        t.equal(metric.name, 'foo_nodejs_gc_duration_seconds', 'Metric should have prepended the prefix to the ".name" property');
+    });
+    collector.start();
+
+    await gc();
+
+    collector.stop();
+});


### PR DESCRIPTION
This appends a GC collector which will collect metrics on how long GCs take. This collector is built on top of the new-ish `perf_hooks` API in node so it does not depend on a C implementation as a lot of other modules does.

Metrics will be collected every time a GC is done so this collector is not part of the scheduled task of collecting system metrics. It runs as a event emitter and emits a histogram.

Collecting GC has a performance impact so this collector is by default turned off. The collector can be turned on by passing `{ gc: true }` to the `.start()` method. I have in this PR also prepared it so that one can turn off / on all the metrics (that needs to be finalized in another PR though). One questions is if turning collection of the different process metrics should be done on the `.start()` method or on the constructor.